### PR TITLE
fixed the issue of maven SNAPSHOT jar not consist in MANIFEST

### DIFF
--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -27,6 +27,7 @@
       <excludes>
         <exclude>junit:junit</exclude>
       </excludes>
+      <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
adding a line in src/main/assembly/assembly.xml
```
<outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}</outputFileNameMapping>
```
based on the answer from Stephen Connolly at: 
https://stackoverflow.com/questions/10525231/maven-snapshot-jar-file-names-not-consistent-using-maven-assembly-in-manifest-fi